### PR TITLE
Allow skipping inclusion of default specifiers

### DIFF
--- a/formatex.inc
+++ b/formatex.inc
@@ -354,6 +354,7 @@ stock printfex(const szFormatString[], {FORMAT_TAGS}:...) {
 	print(s_szBuffer);
 }
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIERS
 // -----------------------------------------------------------------------------------------------------
 // Specifiers
 // -----------------------------------------------------------------------------------------------------
@@ -515,6 +516,7 @@ FormatSpecifier<'v'>(output[], modelid) {
 FormatSpecifier<'X'>(output[], value) {
 	format(output, sizeof(output), "%02x%06x", value >>> 24, value & 0xFFFFFF);
 }
+#endif
 
 // Do this last so the specifiers always use the native function
 #if FORMAT_REPLACE_NATIVES

--- a/formatex.inc
+++ b/formatex.inc
@@ -359,11 +359,14 @@ stock printfex(const szFormatString[], {FORMAT_TAGS}:...) {
 // Specifiers
 // -----------------------------------------------------------------------------------------------------
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIER_C
 // Inline color
 FormatSpecifier<'C'>(output[], color) {
 	format(output, sizeof(output), "{%06x}", color >>> 8);
 }
+#endif
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIER_p
 // Player name
 FormatSpecifier<'p'>(output[], playerid) {
 	if (0 <= playerid < GetMaxPlayers() && IsPlayerConnected(playerid))
@@ -371,7 +374,9 @@ FormatSpecifier<'p'>(output[], playerid) {
 	else
 		strcat(output, "<UNKNOWN>");
 }
+#endif
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIER_P
 // Player name and color
 FormatSpecifier<'P'>(output[], playerid) {
 	if (0 <= playerid < GetMaxPlayers() && IsPlayerConnected(playerid)) {
@@ -381,7 +386,9 @@ FormatSpecifier<'P'>(output[], playerid) {
 	} else
 		strcat(output, "{FFFFFF}<UNKNOWN>");
 }
+#endif
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIER_W
 // Weapon name
 FormatSpecifier<'W'>(output[], weapon) {
 	static const
@@ -413,7 +420,9 @@ FormatSpecifier<'W'>(output[], weapon) {
 	else
 		strcat(output, "Unknown");
 }
+#endif
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIER_w
 // Weapon name, lower-case singular (for sentences)
 FormatSpecifier<'w'>(output[], weapon) {
 	static const
@@ -445,7 +454,9 @@ FormatSpecifier<'w'>(output[], weapon) {
 	else
 		strcat(output, "something unknown");
 }
+#endif
 
+#define FORMAT_NO_DEFAULT_SPECIFIER_v
 // Vehicle name
 FormatSpecifier<'v'>(output[], modelid) {
 	static const
@@ -511,12 +522,16 @@ FormatSpecifier<'v'>(output[], modelid) {
 	else
 		strcat(output, "Unknown");
 }
+#endif
 
+#if !defined FORMAT_NO_DEFAULT_SPECIFIER_X
 // Unsigned 4-byte hex
 FormatSpecifier<'X'>(output[], value) {
 	format(output, sizeof(output), "%02x%06x", value >>> 24, value & 0xFFFFFF);
 }
 #endif
+
+#endif // FORMAT_NO_DEFAULT_SPECIFIERS
 
 // Do this last so the specifiers always use the native function
 #if FORMAT_REPLACE_NATIVES


### PR DESCRIPTION
This PR would allow users to define `FORMAT_NO_DEFAULT_SPECIFIERS` before formatex's inclusion, which would skip compilation of formatex's built in specifiers, in order to allow the main script to use those letters.

The reason I came up with this is because I'm donig a script which will be on a language which is not english, but still, the coding convention inside of it is in English. Therefor, it would be great for the code to specifiers like `%w` while still displaying localized text.

It would be completely optional and will not break any existing scripts that already use formatex. I'm sure that everyone that would use this option will surely know how's the deal with specifiers already and, in case one needs one of the default specifiers back, it's easy to do it by copying the existing ones into your script.