### PR TITLE
Specifier custom fallback values

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,46 @@ FormatSpecifier<'D'>(output[], Text:td) { ... }
 FormatSpecifier<'D'>(output[], const string[]) { ... }
 ```
 
+## Custom fallback values
+formatex allows you to customize the fallback return value of the following specifiers; `%P`, `%p`, `%W`, `%w`, and `%v`:
+
+```pawn
+#define FORMAT_FALLBACK_P "No player found"
+#define FORMAT_FALLBACK_p "{ABCDEF}void!!!"
+#define FORMAT_FALLBACK_W "Tis aint murica"
+#define FORMAT_FALLBACK_w "Ammunation"
+#define FORMAT_FALLBACK_v "Vrum Vrum much?"
+
+#include "formatex.inc"
+
+main() {
+
+	// Passing an invalid playerid
+	printf("%%P: %P", INVALID_PLAYER_ID);
+
+	// Passing an invalid playerid
+	printf("%%p: %p", -59);
+
+	// Passing an invalid weaponid
+	printf("%%W: %W", 9250);
+
+	// Passing an invalid weaponid
+	printf("%%w: %w", -560);
+
+	// Passing an invalid vehicleid
+	printf("%%v: %v", 10);
+}
+```
+
+**Output:**
+```plaintext
+%P: No player found
+%p: {ABCDEF}void!!!
+%W: Tis aint murica
+%w: Ammunation
+%v: Vrum Vrum much?
+```
+
 ## Additional notes
 
 Worth mentioning is this is a superset of format, meaning it has exactly all the

--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
-<h1 align="center">formatex</h1>
+# formatex
 
-<p align="center">
-  <a href=https://github.com/Southclaws/formatex">
-    <img align="center" src="https://img.shields.io/badge/sampctl-formatex-2f2f2f.svg?style=for-the-badge">
-  </a>
-</p>
+[![sampctl](https://shields.southcla.ws/badge/sampctl-formatex-2f2f2f.svg?style=for-the-badge)](https://github.com/Southclaws/formatex)
 
-<p align="center">
-  Slice's formatex because it doesn't have a GitHub repo.
-</p>
-
----
+Slice's formatex because it doesn't have a GitHub repo.
 
 Original thread: http://forum.sa-mp.com/showthread.php?t=313488
 
@@ -114,6 +106,7 @@ FormatSpecifier<'D'>(output[], const string[]) { ... }
 ```
 
 ## Custom fallback values
+
 formatex allows you to customize the fallback return value of the following specifiers; `%P`, `%p`, `%W`, `%w`, and `%v`:
 
 ```pawn
@@ -145,6 +138,7 @@ main() {
 ```
 
 **Output:**
+
 ```plaintext
 %P: No player found
 %p: {ABCDEF}void!!!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-# formatex
+<h1 align="center">formatex</h1>
 
-[![sampctl](https://shields.southcla.ws/badge/sampctl-formatex-2f2f2f.svg?style=for-the-badge)](https://github.com/Southclaws/formatex)
+<p align="center">
+  <a href=https://github.com/Southclaws/formatex">
+    <img align="center" src="https://img.shields.io/badge/sampctl-formatex-2f2f2f.svg?style=for-the-badge">
+  </a>
+</p>
 
-Slice's formatex because it doesn't have a GitHub repo.
+<p align="center">
+  Slice's formatex because it doesn't have a GitHub repo.
+</p>
+
+---
 
 Original thread: http://forum.sa-mp.com/showthread.php?t=313488
 

--- a/formatex.inc
+++ b/formatex.inc
@@ -29,6 +29,7 @@
 	#define FORMAT_REPLACE_NATIVES true
 #endif
 
+
 #define FormatSpecifier<'%1'>(%2[%3],%4)  FMAT@1:F@%1(%2[FORMAT_CUSTOM_SPEC_BUFFER_SIZE],FMAT@2:___unused,%4)
 #define FMAT@2:___unused,%1[              %1[
 #define FMAT@1:%1(%2)                     forward %1(%2); public %1(%2)
@@ -372,16 +373,28 @@ FormatSpecifier<'C'>(output[], color) {
 #endif
 
 #if !defined FORMAT_NO_DEFAULT_SPECIFIER_p
+
+// Fallback value for the “p” specifier
+#if !defined FORMAT_FALLBACK_p
+	#define FORMAT_FALLBACK_p "<UNKNOWN>"
+#endif
+
 // Player name
 FormatSpecifier<'p'>(output[], playerid) {
 	if (0 <= playerid < GetMaxPlayers() && IsPlayerConnected(playerid))
 		GetPlayerName(playerid, output, sizeof(output));
 	else
-		strcat(output, "<UNKNOWN>");
+		strcat(output, #FORMAT_FALLBACK_p);
 }
 #endif
 
 #if !defined FORMAT_NO_DEFAULT_SPECIFIER_P
+
+// Fallback value for the “P” specifier
+#if !defined FORMAT_FALLBACK_P
+	#define FORMAT_FALLBACK_P "{FFFFFF}<UNKNOWN>"
+#endif
+
 // Player name and color
 FormatSpecifier<'P'>(output[], playerid) {
 	if (0 <= playerid < GetMaxPlayers() && IsPlayerConnected(playerid)) {
@@ -389,11 +402,17 @@ FormatSpecifier<'P'>(output[], playerid) {
 		
 		GetPlayerName(playerid, output[8], sizeof(output) - 8);
 	} else
-		strcat(output, "{FFFFFF}<UNKNOWN>");
+		strcat(output, #FORMAT_FALLBACK_P);
 }
 #endif
 
 #if !defined FORMAT_NO_DEFAULT_SPECIFIER_W
+
+// Fallback value for the “W” specifier
+#if !defined FORMAT_FALLBACK_W
+	#define FORMAT_FALLBACK_W "<UNKNOWN>"
+#endif
+
 // Weapon name
 FormatSpecifier<'W'>(output[], weapon) {
 	static const
@@ -423,11 +442,17 @@ FormatSpecifier<'W'>(output[], weapon) {
 	if (0 <= weapon < sizeof(s_WeaponNames))
 		strcat(output, s_WeaponNames[weapon]);
 	else
-		strcat(output, "Unknown");
+		strcat(output, #FORMAT_FALLBACK_W);
 }
 #endif
 
 #if !defined FORMAT_NO_DEFAULT_SPECIFIER_w
+
+// Fallback value for the “w” specifier
+#if !defined FORMAT_FALLBACK_w
+	#define FORMAT_FALLBACK_w "<UNKNOWN>"
+#endif
+
 // Weapon name, lower-case singular (for sentences)
 FormatSpecifier<'w'>(output[], weapon) {
 	static const
@@ -457,11 +482,17 @@ FormatSpecifier<'w'>(output[], weapon) {
 	if (0 <= weapon < sizeof(s_WeaponNamesLowercaseSingular))
 		strcat(output, s_WeaponNamesLowercaseSingular[weapon]);
 	else
-		strcat(output, "something unknown");
+		strcat(output, #FORMAT_FALLBACK_w);
 }
 #endif
 
 #if !defined FORMAT_NO_DEFAULT_SPECIFIER_v
+
+// Fallback value for the “v” specifier
+#if !defined FORMAT_FALLBACK_v
+	#define FORMAT_FALLBACK_v "<UNKNOWN>"
+#endif
+
 // Vehicle name
 FormatSpecifier<'v'>(output[], modelid) {
 	static const
@@ -525,7 +556,7 @@ FormatSpecifier<'v'>(output[], modelid) {
 	if (0 <= (modelid -= 400) < sizeof(s_VehicleNames))
 		strcat(output, s_VehicleNames[modelid]);
 	else
-		strcat(output, "Unknown");
+		strcat(output, #FORMAT_FALLBACK_v);
 }
 #endif
 


### PR DESCRIPTION
This PR adds customizable fallback return values for specifiers, say, you want to return **"PiZzA wItH pInEaPpLe"** when no valid `playerid` is passed to the `p` specifier instead of just <**UNKNOWN**>.

For the following specifiers that come with the include `%P`, `%p`, `%W`, `%w`, and `%v`:
```pawn
#define FORMAT_FALLBACK_P "No player found"
#define FORMAT_FALLBACK_p "{ABCDEF}void!!!"
#define FORMAT_FALLBACK_W "Tis aint murica"
#define FORMAT_FALLBACK_w "Ammunation"
#define FORMAT_FALLBACK_v "Vrum Vrum much?"

#include "formatex.inc"

main() {
	// write tests for libraries here and run "sampctl package run"
	printf("%%P: %P", 0);
	printf("%%p: %p", 0);
	printf("%%W: %W", 9250);
	printf("%%w: %w", -560);
	printf("%%v: %v", 10);
}
```
**Output:** 
![image](https://user-images.githubusercontent.com/22644543/74090761-89367080-4aaf-11ea-855e-cc7853362b21.png)

